### PR TITLE
Fix fatal error on every wf command

### DIFF
--- a/packages/wf-docker-workflow-bundle/src/Configuration/Configuration.php
+++ b/packages/wf-docker-workflow-bundle/src/Configuration/Configuration.php
@@ -279,7 +279,7 @@ class Configuration implements ConfigurationInterface
             if ($this->isConfigLeaf($value) || !\array_key_exists($key, $baseConfig)) {
                 $baseConfig[$key] = $value;
             } else {
-                $baseConfig[$key] = $this->configDeepMerge($baseConfig[$key], $value);
+                $baseConfig[$key] = $this->configDeepMerge($baseConfig[$key] ?? [], $value);
             }
         }
 


### PR DESCRIPTION
We get this error for every wf command: 

```
Argument 1 passed to Wf\DockerWorkflowBundle\Configuration\Configuration::configDeepMerge() must be of the type array, null given, called in /opt/wf-docker-workflow/symfony4
  /vendor/wf-chris/docker-workflow-bundle/src/Configuration/Configuration.php on line 282
```

This modification should fix it.